### PR TITLE
Documentation Spelling Errors and Clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Maiddog <maiddogsrl@gmail.com>", "BeaconBrigade <beaconbrigade@gmail.com>"]
-description = "A Rust libary for handling bluetooth Polar heart rate monitors"
+description = "A Rust libary for handling Bluetooth Polar heart rate monitors"
 documentation = "https://docs.rs/arctic"
 homepage = "https://github.com/Roughsketch/arctic"
 keywords = ["polar", "bluetooth", "heartrate"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![docs-badge][]][docs] [![crates.io version]][crates.io link]
 # Arctic
 
-Rust library for handling Polar bluetooth heart rate monitors.
+Rust library for handling Polar Bluetooth heart rate monitors.
 
-Currently only targetting support for H10 due to lack of other devices.
+Currently only targeting support for H10 due to lack of other devices.
 
 ### Note for MacOS
 

--- a/examples/cli-app/src/backend.rs
+++ b/examples/cli-app/src/backend.rs
@@ -1,4 +1,4 @@
-// Interaction with bluetooth
+// Interaction with Bluetooth
 
 use std::sync::Mutex;
 use arctic::{EventHandler, PmdRead, PolarSensor};
@@ -53,7 +53,7 @@ pub async fn init(polar: &mut PolarSensor, rx: watch::Receiver<bool>) -> Result<
     while !polar.is_connected().await {
         match polar.connect().await {
             Err(arctic::Error::NoBleAdaptor) => {
-                eprintln!("No bluetooth adapter found");
+                eprintln!("No Bluetooth adapter found");
                 return Ok(());
             }
             Err(why) => eprintln!("Could not connect: {:?}", why),

--- a/examples/get-stream-settings/src/main.rs
+++ b/examples/get-stream-settings/src/main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while !polar.is_connected().await {
         match polar.connect().await {
             Err(arctic::Error::NoBleAdaptor) => {
-                println!("No bluetooth adapter found");
+                println!("No Bluetooth adapter found");
                 return Ok(());
             }
             Err(why) => println!("Could not connect: {:?}", why),

--- a/examples/hr-data/src/main.rs
+++ b/examples/hr-data/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while !polar.is_connected().await {
         match polar.connect().await {
             Err(arctic::Error::NoBleAdaptor) => {
-                println!("No bluetooth adapter found");
+                println!("No Bluetooth adapter found");
                 return Ok(());
             }
             Err(why) => println!("Could not connect: {:?}", why),

--- a/examples/multi-threaded/src/back.rs
+++ b/examples/multi-threaded/src/back.rs
@@ -1,4 +1,4 @@
-// Interaction with bluetooth
+// Interaction with Bluetooth
 
 use arctic::{Error, EventHandler, H10MeasurementType, PmdRead, PolarResult, PolarSensor};
 use std::io;
@@ -35,7 +35,7 @@ pub async fn polar_init(polar: &mut PolarSensor, rx: watch::Receiver<bool>) -> P
     while !polar.is_connected().await {
         match polar.connect().await {
             Err(arctic::Error::NoBleAdaptor) => {
-                eprintln!("No bluetooth adapter found");
+                eprintln!("No Bluetooth adapter found");
                 return Ok(());
             }
             Err(why) => eprintln!("Could not connect: {:?}", why),

--- a/examples/print-everything/src/main.rs
+++ b/examples/print-everything/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while !polar.is_connected().await {
         match polar.connect().await {
             Err(arctic::Error::NoBleAdaptor) => {
-                println!("No bluetooth adapter found");
+                println!("No Bluetooth adapter found");
                 return Ok(());
             }
             Err(why) => println!("Could not connect: {:?}", why),

--- a/src/control.rs
+++ b/src/control.rs
@@ -19,9 +19,9 @@ const PMD_DATA_UUID: Uuid = Uuid::from_u128(0xfb005c82_02e7_f387_1cad_8acd2d8df0
 pub enum ControlPointCommand {
     /// Do nothing
     Null = 0,
-    /// Get the measurement settings of every data type in `PolarSensor.data_type`
+    /// Get measurement settings for your data type
     GetMeasurementSettings,
-    /// Start measurement of every data type in `PolarSensor.data_type`
+    /// Start measurement for all data types
     RequestMeasurementStart,
     /// Stop all measurements in `PolarSensor.data_type`
     StopMeasurement,
@@ -273,14 +273,14 @@ impl StreamSettings {
 /// Store data returned from the device after a write to the control point
 #[derive(Debug)]
 pub struct ControlResponse {
-    opcode: ControlPointCommand,
+    op_code: ControlPointCommand,
     measurement_type: H10MeasurementType,
     status: ControlPointResponseCode,
     parameters: Vec<u8>,
 }
 
 impl ControlResponse {
-    /// Create new `ControlResponse`
+    /// Create new [`ControlResponse`]
     pub async fn new(data: Vec<u8>) -> PolarResult<ControlResponse> {
         // We need at least 4 bytes for a complete packet
         if data.len() < 4 {
@@ -290,7 +290,7 @@ impl ControlResponse {
         if data[0] != 0xf0 {
             return Err(Error::InvalidData);
         }
-        let opcode = ControlPointCommand::try_from(data[1]).map_err(|_| Error::InvalidData)?;
+        let op_code = ControlPointCommand::try_from(data[1]).map_err(|_| Error::InvalidData)?;
         let measurement_type =
             H10MeasurementType::try_from(data[2]).map_err(|_| Error::InvalidData)?;
         let status = ControlPointResponseCode::try_from(data[3]).map_err(|_| Error::InvalidData)?;
@@ -301,7 +301,7 @@ impl ControlResponse {
         }
 
         Ok(ControlResponse {
-            opcode,
+            op_code,
             measurement_type,
             status,
             parameters,
@@ -315,7 +315,7 @@ impl ControlResponse {
 
     /// Return op code of this response
     pub fn opcode(&self) -> &ControlPointCommand {
-        &self.opcode
+        &self.op_code
     }
 
     /// Get measurement type
@@ -337,7 +337,7 @@ pub struct ControlPoint {
 }
 
 impl ControlPoint {
-    /// Create new `ControlPoint`
+    /// Create new [`ControlPoint`]
     pub async fn new(device: &Peripheral) -> PolarResult<ControlPoint> {
         let control_point = find_characteristic(device, PMD_CP_UUID).await?;
         let measurement_data = find_characteristic(device, PMD_DATA_UUID).await?;
@@ -348,7 +348,7 @@ impl ControlPoint {
         })
     }
 
-    /// Send command to Control Point
+    /// Send command to [`ControlPoint`]
     pub async fn send_command(&self, device: &Peripheral, data: Vec<u8>) -> PolarResult<()> {
         self.write(device, data).await?;
 
@@ -362,7 +362,7 @@ impl ControlPoint {
             .map_err(Error::BleError)
     }
 
-    /// Read data from control point (for reading the features of a device)
+    /// Read data from [`ControlPoint`] (for reading the features of a device)
     pub async fn read(&self, device: &Peripheral) -> PolarResult<Vec<u8>> {
         device
             .read(&self.control_point)

--- a/src/control.rs
+++ b/src/control.rs
@@ -30,12 +30,12 @@ pub enum ControlPointCommand {
 impl TryFrom<u8> for ControlPointCommand {
     type Error = ();
 
-    fn try_from(val: u8) -> Result<ControlPointCommand, ()> {
+    fn try_from(val: u8) -> Result<Self, ()> {
         match val {
-            0 => Ok(ControlPointCommand::Null),
-            1 => Ok(ControlPointCommand::GetMeasurementSettings),
-            2 => Ok(ControlPointCommand::RequestMeasurementStart),
-            3 => Ok(ControlPointCommand::StopMeasurement),
+            0 => Ok(Self::Null),
+            1 => Ok(Self::GetMeasurementSettings),
+            2 => Ok(Self::RequestMeasurementStart),
+            3 => Ok(Self::StopMeasurement),
             _ => {
                 println!("Invalid ControlPointCommand {}", val);
                 Err(())
@@ -80,22 +80,22 @@ pub enum ControlPointResponseCode {
 impl TryFrom<u8> for ControlPointResponseCode {
     type Error = ();
 
-    fn try_from(val: u8) -> Result<ControlPointResponseCode, ()> {
+    fn try_from(val: u8) -> Result<Self, ()> {
         match val {
-            0 => Ok(ControlPointResponseCode::Success),
-            1 => Ok(ControlPointResponseCode::InvalidOpCode),
-            2 => Ok(ControlPointResponseCode::InvalidMeasurementType),
-            3 => Ok(ControlPointResponseCode::NotSupported),
-            4 => Ok(ControlPointResponseCode::InvalidLength),
-            5 => Ok(ControlPointResponseCode::InvalidParameter),
-            6 => Ok(ControlPointResponseCode::AlreadyInState),
-            7 => Ok(ControlPointResponseCode::InvalidResolution),
-            8 => Ok(ControlPointResponseCode::InvalidSampleRate),
-            9 => Ok(ControlPointResponseCode::InvalidRange),
-            10 => Ok(ControlPointResponseCode::InvalidMTU),
-            11 => Ok(ControlPointResponseCode::InvalidNumberOfChannels),
-            12 => Ok(ControlPointResponseCode::InvalidState),
-            13 => Ok(ControlPointResponseCode::DeviceInCharger),
+            0 => Ok(Self::Success),
+            1 => Ok(Self::InvalidOpCode),
+            2 => Ok(Self::InvalidMeasurementType),
+            3 => Ok(Self::NotSupported),
+            4 => Ok(Self::InvalidLength),
+            5 => Ok(Self::InvalidParameter),
+            6 => Ok(Self::AlreadyInState),
+            7 => Ok(Self::InvalidResolution),
+            8 => Ok(Self::InvalidSampleRate),
+            9 => Ok(Self::InvalidRange),
+            10 => Ok(Self::InvalidMTU),
+            11 => Ok(Self::InvalidNumberOfChannels),
+            12 => Ok(Self::InvalidState),
+            13 => Ok(Self::DeviceInCharger),
             _ => {
                 println!("Invalid ControlPointResponseCode {}", val);
                 Err(())
@@ -129,26 +129,26 @@ enum ResponseCode {
 impl TryFrom<u8> for ResponseCode {
     type Error = ();
 
-    fn try_from(val: u8) -> Result<ResponseCode, ()> {
+    fn try_from(val: u8) -> Result<Self, ()> {
         match val {
-            0 => Ok(ResponseCode::Success),
-            1 => Ok(ResponseCode::InvalidHandle),
-            2 => Ok(ResponseCode::ReadNotPermitted),
-            3 => Ok(ResponseCode::WriteNotPermitted),
-            4 => Ok(ResponseCode::InvalidPdu),
-            5 => Ok(ResponseCode::InsufficientAuthentication),
-            6 => Ok(ResponseCode::RequestNotSupported),
-            7 => Ok(ResponseCode::InvalidOffset),
-            8 => Ok(ResponseCode::InsufficientAuthorization),
-            9 => Ok(ResponseCode::PrepareQueueFull),
-            10 => Ok(ResponseCode::AttributeNotFound),
-            11 => Ok(ResponseCode::AttributeNotLong),
-            12 => Ok(ResponseCode::InsufficientEncryptionKeySize),
-            13 => Ok(ResponseCode::InsufficientAttributeValueLength),
-            14 => Ok(ResponseCode::UnlikelyError),
-            15 => Ok(ResponseCode::InsufficientEncryption),
-            16 => Ok(ResponseCode::UnsupportedGroupType),
-            17 => Ok(ResponseCode::InsufficientResources),
+            0 => Ok(Self::Success),
+            1 => Ok(Self::InvalidHandle),
+            2 => Ok(Self::ReadNotPermitted),
+            3 => Ok(Self::WriteNotPermitted),
+            4 => Ok(Self::InvalidPdu),
+            5 => Ok(Self::InsufficientAuthentication),
+            6 => Ok(Self::RequestNotSupported),
+            7 => Ok(Self::InvalidOffset),
+            8 => Ok(Self::InsufficientAuthorization),
+            9 => Ok(Self::PrepareQueueFull),
+            10 => Ok(Self::AttributeNotFound),
+            11 => Ok(Self::AttributeNotLong),
+            12 => Ok(Self::InsufficientEncryptionKeySize),
+            13 => Ok(Self::InsufficientAttributeValueLength),
+            14 => Ok(Self::UnlikelyError),
+            15 => Ok(Self::InsufficientEncryption),
+            16 => Ok(Self::UnsupportedGroupType),
+            17 => Ok(Self::InsufficientResources),
             _ => {
                 println!("Invalid ResponseCode {}", val);
                 Err(())
@@ -165,11 +165,11 @@ enum SettingType {
 }
 
 impl SettingType {
-    fn from(byte: u8) -> SettingType {
+    const fn from(byte: u8) -> Self {
         match byte {
-            0x00 => SettingType::SampleRate,
-            0x01 => SettingType::Resolution,
-            _ => SettingType::Range,
+            0x00 => Self::SampleRate,
+            0x01 => Self::Resolution,
+            _ => Self::Range,
         }
     }
 }
@@ -191,7 +191,7 @@ pub struct StreamSettings {
 
 impl StreamSettings {
     /// Create new stream settings.
-    pub fn new(resp: &ControlResponse) -> PolarResult<StreamSettings> {
+    pub fn new(resp: &ControlResponse) -> PolarResult<Self> {
         if *resp.opcode() != ControlPointCommand::GetMeasurementSettings {
             return Err(Error::WrongResponse);
         }
@@ -246,7 +246,7 @@ impl StreamSettings {
             None
         };
 
-        Ok(StreamSettings {
+        Ok(Self {
             ty: *resp.data_type(),
             resolution,
             range,
@@ -255,17 +255,17 @@ impl StreamSettings {
     }
 
     /// Getter for the resolution (in bits).
-    pub fn resolution(&self) -> u8 {
+    pub const fn resolution(&self) -> u8 {
         self.resolution
     }
 
     /// Getter for range (ACC only) (in G).
-    pub fn range(&self) -> &Option<Vec<u8>> {
+    pub const fn range(&self) -> &Option<Vec<u8>> {
         &self.range
     }
 
     /// Getter for sample rates (in Hz).
-    pub fn sample_rate(&self) -> &Vec<u8> {
+    pub const fn sample_rate(&self) -> &Vec<u8> {
         &self.sample_rate
     }
 }
@@ -281,7 +281,7 @@ pub struct ControlResponse {
 
 impl ControlResponse {
     /// Create new [`ControlResponse`].
-    pub async fn new(data: Vec<u8>) -> PolarResult<ControlResponse> {
+    pub async fn new(data: Vec<u8>) -> PolarResult<Self> {
         // We need at least 4 bytes for a complete packet
         if data.len() < 4 {
             return Err(Error::InvalidData);
@@ -294,13 +294,13 @@ impl ControlResponse {
         let measurement_type =
             H10MeasurementType::try_from(data[2]).map_err(|_| Error::InvalidData)?;
         let status = ControlPointResponseCode::try_from(data[3]).map_err(|_| Error::InvalidData)?;
-        let mut parameters = Vec::new();
+        let parameters = if data.len() > 5 {
+            data[5..].to_vec()
+        } else {
+            Vec::new()
+        };
 
-        if data.len() > 5 {
-            parameters = data[5..].to_vec();
-        }
-
-        Ok(ControlResponse {
+        Ok(Self {
             op_code,
             measurement_type,
             status,
@@ -309,22 +309,22 @@ impl ControlResponse {
     }
 
     /// Return extra parameters of this response.
-    pub fn parameters(&self) -> &Vec<u8> {
+    pub const fn parameters(&self) -> &Vec<u8> {
         &self.parameters
     }
 
     /// Return op code of this response.
-    pub fn opcode(&self) -> &ControlPointCommand {
+    pub const fn opcode(&self) -> &ControlPointCommand {
         &self.op_code
     }
 
     /// Get measurement type.
-    pub fn data_type(&self) -> &H10MeasurementType {
+    pub const fn data_type(&self) -> &H10MeasurementType {
         &self.measurement_type
     }
 
     /// Get response status.
-    pub fn status(&self) -> &ControlPointResponseCode {
+    pub const fn status(&self) -> &ControlPointResponseCode {
         &self.status
     }
 }
@@ -338,11 +338,11 @@ pub struct ControlPoint {
 
 impl ControlPoint {
     /// Create new [`ControlPoint`].
-    pub async fn new(device: &Peripheral) -> PolarResult<ControlPoint> {
+    pub async fn new(device: &Peripheral) -> PolarResult<Self> {
         let control_point = find_characteristic(device, PMD_CP_UUID).await?;
         let measurement_data = find_characteristic(device, PMD_DATA_UUID).await?;
 
-        Ok(ControlPoint {
+        Ok(Self {
             control_point,
             measurement_data,
         })

--- a/src/control.rs
+++ b/src/control.rs
@@ -9,21 +9,21 @@ use btleplug::api::{Characteristic, Peripheral as _, WriteType};
 use btleplug::platform::Peripheral;
 use uuid::Uuid;
 
-/// Polar Measurement Data Control Point (Read | Write | Indicate)
+/// Polar Measurement Data Control Point (Read | Write | Indicate).
 const PMD_CP_UUID: Uuid = Uuid::from_u128(0xfb005c81_02e7_f387_1cad_8acd2d8df0c8);
-/// Polar Measurement Data... Data (Notify)
+/// Polar Measurement Data... Data (Notify).
 const PMD_DATA_UUID: Uuid = Uuid::from_u128(0xfb005c82_02e7_f387_1cad_8acd2d8df0c8);
 
-/// Command options to write to the control point
+/// Command options to write to the control point.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ControlPointCommand {
-    /// Do nothing
+    /// Do nothing.
     Null = 0,
-    /// Get measurement settings for your data type
+    /// Get measurement settings for your data type.
     GetMeasurementSettings,
-    /// Start measurement for all data types
+    /// Start measurement for all data types.
     RequestMeasurementStart,
-    /// Stop all measurements in `PolarSensor.data_type`
+    /// Stop all measurements in `PolarSensor.data_type`.
     StopMeasurement,
 }
 
@@ -44,36 +44,36 @@ impl TryFrom<u8> for ControlPointCommand {
     }
 }
 
-/// Response code returned after a write to PMD control point
+/// Response code returned after a write to PMD control point.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ControlPointResponseCode {
-    /// Command was successful
+    /// Command was successful.
     Success = 0,
-    /// Control point command is not supported by device
+    /// Control point command is not supported by device.
     InvalidOpCode,
-    /// Device does not know the specified measurement type
+    /// Device does not know the specified measurement type.
     InvalidMeasurementType,
-    /// This measurement is not supported by device
+    /// This measurement is not supported by device.
     NotSupported,
-    /// Given length does not match the received data
+    /// Given length does not match the received data.
     InvalidLength,
-    /// Contains parameters that prevent successful handling of request
+    /// Contains parameters that prevent successful handling of request.
     InvalidParameter,
-    /// Device is already in the requested state
+    /// Device is already in the requested state.
     AlreadyInState,
-    /// Requested resolution is not supported by device
+    /// Requested resolution is not supported by device.
     InvalidResolution,
-    /// Requested sample rate is not supported by device
+    /// Requested sample rate is not supported by device.
     InvalidSampleRate,
-    /// Requested range is not supported
+    /// Requested range is not supported.
     InvalidRange,
-    /// Connection MTU does not match device required MTU
+    /// Connection MTU does not match device required MTU.
     InvalidMTU,
-    /// Request contains invalid number of channels
+    /// Request contains invalid number of channels.
     InvalidNumberOfChannels,
-    /// Device is in invalid state
+    /// Device is in invalid state.
     InvalidState,
-    /// Device is in charger and does not support requests
+    /// Device is in charger and does not support requests.
     DeviceInCharger,
 }
 
@@ -180,7 +180,7 @@ enum PmdByteType {
     Data,
 }
 
-/// Struct to store the settings for a specific stream on your device
+/// Struct to store the settings for a specific stream on your device.
 #[derive(Debug, PartialEq, Eq)]
 pub struct StreamSettings {
     ty: H10MeasurementType,
@@ -190,7 +190,7 @@ pub struct StreamSettings {
 }
 
 impl StreamSettings {
-    /// Create new stream settings
+    /// Create new stream settings.
     pub fn new(resp: &ControlResponse) -> PolarResult<StreamSettings> {
         if *resp.opcode() != ControlPointCommand::GetMeasurementSettings {
             return Err(Error::WrongResponse);
@@ -254,23 +254,23 @@ impl StreamSettings {
         })
     }
 
-    /// Getter for the resolution (in bits)
+    /// Getter for the resolution (in bits).
     pub fn resolution(&self) -> u8 {
         self.resolution
     }
 
-    /// Getter for range (ACC only) (in G)
+    /// Getter for range (ACC only) (in G).
     pub fn range(&self) -> &Option<Vec<u8>> {
         &self.range
     }
 
-    /// Getter for sample rates (in Hz)
+    /// Getter for sample rates (in Hz).
     pub fn sample_rate(&self) -> &Vec<u8> {
         &self.sample_rate
     }
 }
 
-/// Store data returned from the device after a write to the control point
+/// Store data returned from the device after a write to the control point.
 #[derive(Debug)]
 pub struct ControlResponse {
     op_code: ControlPointCommand,
@@ -280,7 +280,7 @@ pub struct ControlResponse {
 }
 
 impl ControlResponse {
-    /// Create new [`ControlResponse`]
+    /// Create new [`ControlResponse`].
     pub async fn new(data: Vec<u8>) -> PolarResult<ControlResponse> {
         // We need at least 4 bytes for a complete packet
         if data.len() < 4 {
@@ -308,28 +308,28 @@ impl ControlResponse {
         })
     }
 
-    /// Return extra parameters of this response
+    /// Return extra parameters of this response.
     pub fn parameters(&self) -> &Vec<u8> {
         &self.parameters
     }
 
-    /// Return op code of this response
+    /// Return op code of this response.
     pub fn opcode(&self) -> &ControlPointCommand {
         &self.op_code
     }
 
-    /// Get measurement type
+    /// Get measurement type.
     pub fn data_type(&self) -> &H10MeasurementType {
         &self.measurement_type
     }
 
-    /// Get response status
+    /// Get response status.
     pub fn status(&self) -> &ControlPointResponseCode {
         &self.status
     }
 }
 
-/// Struct that has access to the PMD control point point and PMD data
+/// Struct that has access to the PMD control point point and PMD data.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ControlPoint {
     control_point: Characteristic,
@@ -337,7 +337,7 @@ pub struct ControlPoint {
 }
 
 impl ControlPoint {
-    /// Create new [`ControlPoint`]
+    /// Create new [`ControlPoint`].
     pub async fn new(device: &Peripheral) -> PolarResult<ControlPoint> {
         let control_point = find_characteristic(device, PMD_CP_UUID).await?;
         let measurement_data = find_characteristic(device, PMD_DATA_UUID).await?;
@@ -348,7 +348,7 @@ impl ControlPoint {
         })
     }
 
-    /// Send command to [`ControlPoint`]
+    /// Send command to [`ControlPoint`].
     pub async fn send_command(&self, device: &Peripheral, data: Vec<u8>) -> PolarResult<()> {
         self.write(device, data).await?;
 
@@ -362,7 +362,7 @@ impl ControlPoint {
             .map_err(Error::BleError)
     }
 
-    /// Read data from [`ControlPoint`] (for reading the features of a device)
+    /// Read data from [`ControlPoint`] (for reading the features of a device).
     pub async fn read(&self, device: &Peripheral) -> PolarResult<Vec<u8>> {
         device
             .read(&self.control_point)

--- a/src/control.rs
+++ b/src/control.rs
@@ -313,7 +313,7 @@ impl ControlResponse {
         &self.parameters
     }
 
-    /// Return opcode of this response
+    /// Return op code of this response
     pub fn opcode(&self) -> &ControlPointCommand {
         &self.opcode
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use response::{Acc, Ecg, HeartRate, PmdData, PmdRead};
 /// Error type for general errors and Ble errors from btleplug
 #[derive(Debug)]
 pub enum Error {
-    /// Not Bluetooth adapter found when trying to scan
+    /// No Bluetooth adapter found when trying to scan
     NoBleAdaptor,
     /// Could not create control point link
     NoControlPoint,
@@ -98,7 +98,7 @@ pub enum Error {
     NullCommand,
     /// Tried to create a struct using the wrong control point response
     WrongResponse,
-    /// Tried to set a setting using with a `H10MeasurementType` that doesn't support that feature
+    /// Tried to set a setting using with a [`H10MeasurementType`] that doesn't support that feature
     WrongType,
     /// An error occurred in the underlying BLE library
     BleError(btleplug::Error),
@@ -181,7 +181,7 @@ pub struct SupportedFeatures {
 }
 
 impl SupportedFeatures {
-    /// Create `SupportedFeatures`
+    /// Create [`SupportedFeatures`]
     pub fn new(mes: u8) -> SupportedFeatures {
         SupportedFeatures {
             ecg: (mes & 0b00000001) != 0,
@@ -210,7 +210,7 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when measurement data is received over the PMD data UUID
     ///
-    /// Contains data in a `PmdRead`
+    /// Contains data in a [`PmdRead`]
     async fn measurement_update(&self, _ctx: &PolarSensor, _data: PmdRead) {}
 
     /// Checked at start of each event loop
@@ -261,7 +261,7 @@ impl From<NotifyStream> for Uuid {
 /// // Do the actual connection. This will find the device and start the Bluetooth connection
 /// polar.connect().await.unwrap();
 /// # }
-/// // Can now subscribe to events, set event handler, run event_loop, etc
+/// // Can now subscribe to events, set event handler, run the event loop, etc
 /// ```
 pub struct PolarSensor {
     /// The device id written on the device (e.g, "8C4CAD2D")
@@ -464,7 +464,7 @@ impl PolarSensor {
         );
     }
 
-    /// Start measurement stream for `self.data_type`
+    /// Start measurement stream for one [`H10MeasurementType`]
     ///
     /// # Errors
     ///
@@ -720,9 +720,9 @@ impl PolarSensor {
     /// # Warning
     ///
     /// If the event is started without subscribing to anything, the event loop can hang forever,
-    /// and the closing condition trait function for `EventHandler` can't even close the loop.
-    /// Additionally, if you're only subscribed to `MeasurementData`, you have to make sure to
-    /// add a measurement type. Subscribing to `MeasurementCP` or `Battery` only also can cause
+    /// and the closing condition trait function for [`EventHandler`] can't even close the loop.
+    /// Additionally, if you're only subscribed to [`NotifyStream::MeasurementData`], you have to make sure to
+    /// add a measurement type. Subscribing to [`NotifyStream::MeasurementCP`] or [`NotifyStream::Battery`] only also can cause
     /// issues because they will send notifications rarely.
     pub async fn event_loop(&self) -> PolarResult<()> {
         // Stop any previous measurements that might not have been stopped properly
@@ -805,7 +805,7 @@ impl PolarSensor {
     }
 }
 
-/// Private helper to find characteristics from a UUID
+/// Private helper to find characteristics from a [`Uuid`]
 async fn find_characteristic(device: &Peripheral, uuid: Uuid) -> PolarResult<Characteristic> {
     device
         .characteristics()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Arctic
 //!
-//! arctic is a library for interacting with bluetooth Polar heart rate devices.
-//! It uses btleplug as the bluetooth backend which supports Windows, Mac, and Linux
+//! arctic is a library for interacting with Bluetooth Polar heart rate devices.
+//! It uses btleplug as the Bluetooth backend which supports Windows, Mac, and Linux
 //!
 //! ## Usage
 //!
@@ -30,8 +30,8 @@
 //!     while !polar.is_connected().await {
 //!         match polar.connect().await {
 //!             Err(ArcticError::NoBleAdaptor) => {
-//!                 // If there's no bluetooth adapter this library cannot work, so return.
-//!                 println!("No bluetooth adapter found");
+//!                 // If there's no Bluetooth adapter this library cannot work, so return.
+//!                 println!("No Bluetooth adapter found");
 //!                 return Ok(());
 //!             }
 //!             Err(why) => println!("Could not connect: {:?}", why),
@@ -78,7 +78,7 @@ pub use response::{Acc, Ecg, HeartRate, PmdData, PmdRead};
 /// Error type for general errors and Ble errors from btleplug
 #[derive(Debug)]
 pub enum Error {
-    /// Not bluetooth adapter found when trying to scan
+    /// Not Bluetooth adapter found when trying to scan
     NoBleAdaptor,
     /// Could not create control point link
     NoControlPoint,
@@ -232,7 +232,7 @@ pub enum NotifyStream {
     HeartRate,
     /// Receive updates from the control points, only for use within the library
     MeasurementCP,
-    /// Receive updates from the PMD data stream (acceleration or ecg)
+    /// Receive updates from the PMD data stream (acceleration or ECG)
     MeasurementData,
 }
 
@@ -252,13 +252,13 @@ impl From<NotifyStream> for Uuid {
 /// // Create the initial object. The new function takes a device ID which it
 /// // will use to find the device to connect to.
 /// // Internally, this will set the device_id and create a
-/// // a bluetooth connection manager, but it will not connect.
+/// // a Bluetooth connection manager, but it will not connect.
 /// # use arctic::PolarSensor;
 /// # #[tokio::main]
 /// # async fn main() {
 /// let mut polar = PolarSensor::new("7B45F72B".to_string()).await.unwrap();
 ///
-/// // Do the actual connection. This will find the device and start the bluetooth connection
+/// // Do the actual connection. This will find the device and start the Bluetooth connection
 /// polar.connect().await.unwrap();
 /// # }
 /// // Can now subscribe to events, set event handler, run event_loop, etc
@@ -272,22 +272,22 @@ pub struct PolarSensor {
     ble_device: Option<Peripheral>,
     /// Handler for event callbacks
     event_handler: Option<Arc<dyn EventHandler>>,
-    /// Control point accessor
+    /// Control point accessory
     control_point: Option<ControlPoint>,
     /// Current type of info gathered
     data_type: Option<Vec<H10MeasurementType>>,
     /// Range of 2G, 4G or 8G (only for ACC)
     range: u8,
-    /// Sample rate in hz
+    /// Sample rate in Hz
     sample_rate: u8,
 }
 
 impl PolarSensor {
-    /// Creates a new PolarSensor.
+    /// Creates a new [`PolarSensor`].
     ///
     /// # Errors
     ///
-    /// Returns a [`Error::BleError`] if the bluetooth manager could not be created
+    /// Returns a [`Error::BleError`] if the Bluetooth manager could not be created
     pub async fn new(device_id: String) -> PolarResult<PolarSensor> {
         let ble_manager = Manager::new().await.map_err(Error::BleError)?;
 
@@ -312,13 +312,13 @@ impl PolarSensor {
     /// # Errors
     ///
     /// Returns a [`Error::BleError`] if:
-    /// - Unable to get bluetooth adapters
+    /// - Unable to get Bluetooth adapters
     /// - Unable to scan for devices
     /// - Unable to discover services for a device
     /// Also returns [`Error::NoBleAdaptor`] if there are no adapters available
     /// Can also return [`Error::NotConnected`] if no device was found
     pub async fn connect(&mut self) -> PolarResult<()> {
-        // get the first bluetooth adapter
+        // get the first Bluetooth adapter
         let adapters_result = self.ble_manager.adapters().await.map_err(Error::BleError);
 
         if let Ok(adapters) = adapters_result {
@@ -406,7 +406,7 @@ impl PolarSensor {
         false
     }
 
-    /// Returns the rssi of your device and the H10, or None if you have no device
+    /// Returns the RSSI of your device and the H10, or None if you have no device
     pub async fn rssi(&self) -> Option<i16> {
         let device = self.device().await.ok()?;
 
@@ -805,7 +805,7 @@ impl PolarSensor {
     }
 }
 
-/// Private helper to find characteristics from a uuid
+/// Private helper to find characteristics from a UUID
 async fn find_characteristic(device: &Peripheral, uuid: Uuid) -> PolarResult<Characteristic> {
     device
         .characteristics()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,18 +107,18 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {
-            Error::NoBleAdaptor => "No BLE adaptor".to_string(),
-            Error::NoControlPoint => "No control point".to_string(),
-            Error::NoDevice => "No device".to_string(),
-            Error::NotConnected => "Not connected".to_string(),
-            Error::NoDataType => "No data type".to_string(),
-            Error::CharacteristicNotFound => "Characteristic not found".to_string(),
-            Error::InvalidData => "Invalid data".to_string(),
-            Error::InvalidLength => "Invalid length".to_string(),
-            Error::NullCommand => "Null command".to_string(),
-            Error::WrongResponse => "Wrong response".to_string(),
-            Error::WrongType => "Wrong type".to_string(),
-            Error::BleError(er) => format!("BLE error: {:?}", er),
+            Self::NoBleAdaptor => "No BLE adaptor".to_string(),
+            Self::NoControlPoint => "No control point".to_string(),
+            Self::NoDevice => "No device".to_string(),
+            Self::NotConnected => "Not connected".to_string(),
+            Self::NoDataType => "No data type".to_string(),
+            Self::CharacteristicNotFound => "Characteristic not found".to_string(),
+            Self::InvalidData => "Invalid data".to_string(),
+            Self::InvalidLength => "Invalid length".to_string(),
+            Self::NullCommand => "Null command".to_string(),
+            Self::WrongResponse => "Wrong response".to_string(),
+            Self::WrongType => "Wrong type".to_string(),
+            Self::BleError(er) => format!("BLE error: {:?}", er),
         };
         write!(f, "Arctic Error: {}", msg)
     }
@@ -138,27 +138,27 @@ pub enum H10MeasurementType {
 impl TryFrom<u8> for H10MeasurementType {
     type Error = ();
 
-    fn try_from(data: u8) -> Result<H10MeasurementType, ()> {
+    fn try_from(data: u8) -> Result<Self, ()> {
         match data {
-            0x0 => Ok(H10MeasurementType::Ecg),
-            0x2 => Ok(H10MeasurementType::Acc),
+            0x0 => Ok(Self::Ecg),
+            0x2 => Ok(Self::Acc),
             _ => Err(()),
         }
     }
 }
 
 impl H10MeasurementType {
-    fn as_u8(&self) -> u8 {
+    const fn as_u8(&self) -> u8 {
         match *self {
-            H10MeasurementType::Ecg => 0x0,
-            H10MeasurementType::Acc => 0x2,
+            Self::Ecg => 0x0,
+            Self::Acc => 0x2,
         }
     }
 
-    fn as_bytes(&self) -> u8 {
+    const fn as_bytes(&self) -> u8 {
         match *self {
-            H10MeasurementType::Ecg => 3,
-            H10MeasurementType::Acc => 6,
+            Self::Ecg => 3,
+            Self::Acc => 6,
         }
     }
 }
@@ -182,15 +182,15 @@ pub struct SupportedFeatures {
 
 impl SupportedFeatures {
     /// Create [`SupportedFeatures`].
-    pub fn new(mes: u8) -> SupportedFeatures {
-        SupportedFeatures {
-            ecg: (mes & 0b00000001) != 0,
-            ppg: (mes & 0b00000010) != 0,
-            acc: (mes & 0b00000100) != 0,
-            ppi: (mes & 0b00001000) != 0,
-            // rfu       0b00010000
-            gyro: (mes & 0b00100000) != 0,
-            mag: (mes & 0b01000000) != 0,
+    pub const fn new(mes: u8) -> Self {
+        Self {
+            ecg: (mes & 0b0000_0001) != 0,
+            ppg: (mes & 0b0000_0010) != 0,
+            acc: (mes & 0b0000_0100) != 0,
+            ppi: (mes & 0b0000_1000) != 0,
+            // rfu       0b0001_0000
+            gyro: (mes & 0b0010_0000) != 0,
+            mag: (mes & 0b0100_0000) != 0,
         }
     }
 }
@@ -288,14 +288,14 @@ impl PolarSensor {
     /// # Errors
     ///
     /// Returns a [`Error::BleError`] if the Bluetooth manager could not be created.
-    pub async fn new(device_id: String) -> PolarResult<PolarSensor> {
+    pub async fn new(device_id: String) -> PolarResult<Self> {
         let ble_manager = Manager::new().await.map_err(Error::BleError)?;
 
         if device_id.len() != 8 {
             return Err(Error::InvalidLength);
         }
 
-        Ok(PolarSensor {
+        Ok(Self {
             device_id,
             ble_manager,
             ble_device: None,
@@ -609,7 +609,7 @@ impl PolarSensor {
     }
 
     /// Get data types.
-    pub fn data_type(&self) -> &Option<Vec<H10MeasurementType>> {
+    pub const fn data_type(&self) -> &Option<Vec<H10MeasurementType>> {
         &self.data_type
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 //! # Arctic
 //!
 //! arctic is a library for interacting with Bluetooth Polar heart rate devices.
-//! It uses btleplug as the Bluetooth backend which supports Windows, Mac, and Linux
+//! It uses btleplug as the Bluetooth backend which supports Windows, Mac, and Linux.
 //!
 //! ## Usage
 //!
-//! Example of how to use the library to keep track of heart rate from a Polar H10
+//! Example of how to use the library to keep track of heart rate from a Polar H10.
 //!
 //! ```rust,no_run
 //! use arctic::{async_trait, Error as ArcticError, EventHandler, NotifyStream, PolarSensor, HeartRate};
@@ -14,7 +14,7 @@
 //!
 //! #[async_trait]
 //! impl EventHandler for Handler {
-//!     // Handler for heart rate events
+//!     // Handler for heart rate events.
 //!     async fn heart_rate_update(&self, _ctx: &PolarSensor, heartrate: HeartRate) {
 //!         println!("Heart rate: {:?}", heartrate);
 //!     }
@@ -39,15 +39,15 @@
 //!         }
 //!     }
 //!
-//!     // Subscribe to heart rate events
+//!     // Subscribe to heart rate events.
 //!     if let Err(why) = polar.subscribe(NotifyStream::HeartRate).await {
 //!         println!("Could not subscribe to heart rate notifications: {:?}", why)
 //!     }
 //!
-//!     // Set the event handler to our struct defined above
+//!     // Set the event handler to our struct defined above.
 //!     polar.event_handler(Handler);
 //!
-//!     // Run the event loop until it ends
+//!     // Run the event loop until it ends.
 //!     let result = polar.event_loop().await;
 //!     println!("No more data: {:?}", result);
 //!     Ok(())
@@ -75,32 +75,32 @@ pub use control::{
 use polar_uuid::{NotifyUuid, StringUuid};
 pub use response::{Acc, Ecg, HeartRate, PmdData, PmdRead};
 
-/// Error type for general errors and Ble errors from btleplug
+/// Error type for general errors and Ble errors from btleplug.
 #[derive(Debug)]
 pub enum Error {
-    /// No Bluetooth adapter found when trying to scan
+    /// No Bluetooth adapter found when trying to scan.
     NoBleAdaptor,
-    /// Could not create control point link
+    /// Could not create control point link.
     NoControlPoint,
-    /// Could not find a device when trying to connect
+    /// Could not find a device when trying to connect.
     NoDevice,
-    /// Device is not connected, but function was called that requires it
+    /// Device is not connected, but function was called that requires it.
     NotConnected,
-    /// No measurement type selected
+    /// No measurement type selected.
     NoDataType,
-    /// Device is missing a characteristic that was used
+    /// Device is missing a characteristic that was used.
     CharacteristicNotFound,
-    /// Data packets received from device could not be parsed
+    /// Data packets received from device could not be parsed.
     InvalidData,
-    /// Not enough data was received
+    /// Not enough data was received.
     InvalidLength,
-    /// Command to write to PMD control point is Null
+    /// Command to write to PMD control point is Null.
     NullCommand,
-    /// Tried to create a struct using the wrong control point response
+    /// Tried to create a struct using the wrong control point response.
     WrongResponse,
-    /// Tried to set a setting using with a [`H10MeasurementType`] that doesn't support that feature
+    /// Tried to set a setting using with a [`H10MeasurementType`] that doesn't support that feature.
     WrongType,
-    /// An error occurred in the underlying BLE library
+    /// An error occurred in the underlying BLE library.
     BleError(btleplug::Error),
 }
 
@@ -126,12 +126,12 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-/// List of measurement types you can request
+/// List of measurement types you can request.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum H10MeasurementType {
-    /// Volts (V)
+    /// Volts (V).
     Ecg,
-    /// Force per unit mass (mG)
+    /// Force per unit mass (mG).
     Acc,
 }
 
@@ -163,25 +163,25 @@ impl H10MeasurementType {
     }
 }
 
-/// Struct that reads what features are available on your device
+/// Struct that reads what features are available on your device.
 #[derive(Debug)]
 pub struct SupportedFeatures {
-    /// Electrocardiogram
+    /// Electrocardiogram.
     pub ecg: bool,
-    /// Photoplethysmography
+    /// Photoplethysmography.
     pub ppg: bool,
-    /// Acceleration
+    /// Acceleration.
     pub acc: bool,
-    /// Peak to peak
+    /// Peak to peak.
     pub ppi: bool,
-    /// Gyroscope
+    /// Gyroscope.
     pub gyro: bool,
-    /// Magnetometer
+    /// Magnetometer.
     pub mag: bool,
 }
 
 impl SupportedFeatures {
-    /// Create [`SupportedFeatures`]
+    /// Create [`SupportedFeatures`].
     pub fn new(mes: u8) -> SupportedFeatures {
         SupportedFeatures {
             ecg: (mes & 0b00000001) != 0,
@@ -195,7 +195,7 @@ impl SupportedFeatures {
     }
 }
 
-/// Trait for handling events coming from a device
+/// Trait for handling events coming from a device.
 #[async_trait]
 pub trait EventHandler: Send + Sync {
     /// Dispatched when a battery update is received.
@@ -203,36 +203,36 @@ pub trait EventHandler: Send + Sync {
     /// Contains the current battery level.
     async fn battery_update(&self, _battery_level: u8) {}
 
-    /// Dispatched when a heart rate update is received
+    /// Dispatched when a heart rate update is received.
     ///
-    /// Contains information about the heart rate and R-R timing
+    /// Contains information about the heart rate and R-R timing.
     async fn heart_rate_update(&self, _ctx: &PolarSensor, _heartrate: HeartRate) {}
 
-    /// Dispatched when measurement data is received over the PMD data UUID
+    /// Dispatched when measurement data is received over the PMD data UUID.
     ///
-    /// Contains data in a [`PmdRead`]
+    /// Contains data in a [`PmdRead`].
     async fn measurement_update(&self, _ctx: &PolarSensor, _data: PmdRead) {}
 
-    /// Checked at start of each event loop
+    /// Checked at start of each event loop.
     ///
-    /// Returns `false` if the event loop should terminate and close up
+    /// Returns [`false`] if the event loop should terminate and close up.
     async fn should_continue(&self) -> bool {
         true
     }
 }
 
-/// Result simplification type
+/// Result simplification type.
 pub type PolarResult<T> = std::result::Result<T, Error>;
 
-/// A list of stream types that can be subscribed to
+/// A list of stream types that can be subscribed to.
 pub enum NotifyStream {
-    /// Receive battery updates
+    /// Receive battery updates.
     Battery,
-    /// Receive heart rate updates
+    /// Receive heart rate updates.
     HeartRate,
-    /// Receive updates from the control points, only for use within the library
+    /// Receive updates from the control points, only for use within the library.
     MeasurementCP,
-    /// Receive updates from the PMD data stream (acceleration or ECG)
+    /// Receive updates from the PMD data stream (acceleration or ECG).
     MeasurementData,
 }
 
@@ -246,7 +246,7 @@ impl From<NotifyStream> for Uuid {
 ///
 /// ## Example
 ///
-/// Order of operations for connecting and using a `PolarSensor`
+/// Order of operations for connecting and using a [`PolarSensor`].
 ///
 /// ```rust,no_run
 /// // Create the initial object. The new function takes a device ID which it
@@ -258,27 +258,27 @@ impl From<NotifyStream> for Uuid {
 /// # async fn main() {
 /// let mut polar = PolarSensor::new("7B45F72B".to_string()).await.unwrap();
 ///
-/// // Do the actual connection. This will find the device and start the Bluetooth connection
+/// // Do the actual connection. This will find the device and start the Bluetooth connection.
 /// polar.connect().await.unwrap();
 /// # }
-/// // Can now subscribe to events, set event handler, run the event loop, etc
+/// // Can now subscribe to events, set event handler, run the event loop, etc.
 /// ```
 pub struct PolarSensor {
-    /// The device id written on the device (e.g, "8C4CAD2D")
+    /// The device id written on the device (e.g, "8C4CAD2D").
     device_id: String,
-    /// BLE connection handlers
+    /// BLE connection handlers.
     ble_manager: Manager,
-    /// The connection to the device
+    /// The connection to the device.
     ble_device: Option<Peripheral>,
-    /// Handler for event callbacks
+    /// Handler for event callbacks.
     event_handler: Option<Arc<dyn EventHandler>>,
-    /// Control point accessory
+    /// Control point accessory.
     control_point: Option<ControlPoint>,
-    /// Current type of info gathered
+    /// Current type of info gathered.
     data_type: Option<Vec<H10MeasurementType>>,
-    /// Range of 2G, 4G or 8G (only for ACC)
+    /// Range of 2G, 4G or 8G (only for ACC).
     range: u8,
-    /// Sample rate in Hz
+    /// Sample rate in Hz.
     sample_rate: u8,
 }
 
@@ -287,7 +287,7 @@ impl PolarSensor {
     ///
     /// # Errors
     ///
-    /// Returns a [`Error::BleError`] if the Bluetooth manager could not be created
+    /// Returns a [`Error::BleError`] if the Bluetooth manager could not be created.
     pub async fn new(device_id: String) -> PolarResult<PolarSensor> {
         let ble_manager = Manager::new().await.map_err(Error::BleError)?;
 
@@ -312,11 +312,11 @@ impl PolarSensor {
     /// # Errors
     ///
     /// Returns a [`Error::BleError`] if:
-    /// - Unable to get Bluetooth adapters
-    /// - Unable to scan for devices
-    /// - Unable to discover services for a device
-    /// Also returns [`Error::NoBleAdaptor`] if there are no adapters available
-    /// Can also return [`Error::NotConnected`] if no device was found
+    /// - Unable to get Bluetooth adapters.
+    /// - Unable to scan for devices.
+    /// - Unable to discover services for a device.
+    /// Also returns [`Error::NoBleAdaptor`] if there are no adapters available.
+    /// Can also return [`Error::NotConnected`] if no device was found.
     pub async fn connect(&mut self) -> PolarResult<()> {
         // get the first Bluetooth adapter
         let adapters_result = self.ble_manager.adapters().await.map_err(Error::BleError);
@@ -355,9 +355,9 @@ impl PolarSensor {
     /// # Errors
     ///
     /// Will return:
-    /// - [`Error::NotConnected`] if the device is not currently connected
-    /// - [`Error::CharacteristicNotFound`] if a given notify type is not found on the device
-    /// - [`Error::BleError`] if there is an error subscribing to the event
+    /// - [`Error::NotConnected`] if the device is not currently connected.
+    /// - [`Error::CharacteristicNotFound`] if a given notify type is not found on the device.
+    /// - [`Error::BleError`] if there is an error subscribing to the event.
     pub async fn subscribe(&self, stream: NotifyStream) -> PolarResult<()> {
         let device = self.device().await?;
 
@@ -377,9 +377,9 @@ impl PolarSensor {
     /// # Errors
     ///
     /// Will return:
-    /// - [`Error::NotConnected`] if the device isn't connected
-    /// - [`Error::CharacteristicNotFound`] if the specified notify type isn't found on the device
-    /// - [`Error::BleError`] if there is an error subscribing to the event from within BLE
+    /// - [`Error::NotConnected`] if the device isn't connected.
+    /// - [`Error::CharacteristicNotFound`] if the specified notify type isn't found on the device.
+    /// - [`Error::BleError`] if there is an error subscribing to the event from within BLE.
     pub async fn unsubscribe(&self, stream: NotifyStream) -> PolarResult<()> {
         let device = self.device().await?;
 
@@ -395,7 +395,7 @@ impl PolarSensor {
         Err(Error::NotConnected)
     }
 
-    /// Returns whether the device is currently connected or not
+    /// Returns whether the device is currently connected or not.
     pub async fn is_connected(&self) -> bool {
         if let Some(device) = &self.ble_device {
             if let Ok(value) = device.is_connected().await {
@@ -406,7 +406,7 @@ impl PolarSensor {
         false
     }
 
-    /// Returns the RSSI of your device and the H10, or None if you have no device
+    /// Returns the RSSI of your device and the H10, or None if you have no device.
     pub async fn rssi(&self) -> Option<i16> {
         let device = self.device().await.ok()?;
 
@@ -456,7 +456,7 @@ impl PolarSensor {
         );
     }
 
-    /// Prints the body location of your device
+    /// Prints the body location of your device.
     pub async fn body_location(&self) {
         println!(
             "Body Location: {:?}",
@@ -464,11 +464,11 @@ impl PolarSensor {
         );
     }
 
-    /// Start measurement stream for one [`H10MeasurementType`]
+    /// Start measurement stream for one [`H10MeasurementType`].
     ///
     /// # Errors
     ///
-    /// - [`Error::NoControlPoint`] if you haven't set a controller
+    /// - [`Error::NoControlPoint`] if you haven't set a controller.
     async fn start_measurement(&self, ty: H10MeasurementType) -> PolarResult<()> {
         let controller = self.controller().await?;
         let mut command = vec![0x02u8, ty.as_u8()];
@@ -514,12 +514,12 @@ impl PolarSensor {
         Ok(())
     }
 
-    /// End measurement stream for `self.data_type`
+    /// End measurement stream for [`H10MeasurementType`]
     ///
     /// # Errors
     ///
-    /// - [`Error::NoControlPoint`] if you haven't set a controller
-    /// - [`Error::NoDataType`] if you haven't set a data type
+    /// - [`Error::NoControlPoint`] if you haven't set a controller.
+    /// - [`Error::NoDataType`] if you haven't set a data type.
     async fn stop_measurement(&self, data_type: H10MeasurementType) -> PolarResult<()> {
         let controller = self.controller().await?;
         controller
@@ -527,7 +527,7 @@ impl PolarSensor {
             .await
     }
 
-    /// Gets the measurement settings of your H10
+    /// Gets the measurement settings of your H10.
     pub async fn settings(&self) -> PolarResult<Vec<StreamSettings>> {
         let mut out: Vec<StreamSettings> = vec![];
 
@@ -553,7 +553,7 @@ impl PolarSensor {
             .await
     }
 
-    /// Request the SDK features from your H10
+    /// Request the SDK features from your H10.
     pub async fn features(&self) -> PolarResult<SupportedFeatures> {
         if let Ok(controller) = self.controller().await {
             if let Ok(device) = self.device().await {
@@ -572,19 +572,19 @@ impl PolarSensor {
         Err(Error::NoControlPoint)
     }
 
-    /// Start measurement while event loop is running
+    /// Start measurement while event loop is running.
     pub async fn start(&self, ty: H10MeasurementType) -> PolarResult<ControlResponse> {
         self.get_pmd_response(ControlPointCommand::RequestMeasurementStart, ty)
             .await
     }
 
-    /// Stop measurement while event loop is running
+    /// Stop measurement while event loop is running.
     pub async fn stop(&self, ty: H10MeasurementType) -> PolarResult<ControlResponse> {
         self.get_pmd_response(ControlPointCommand::StopMeasurement, ty)
             .await
     }
 
-    /// Adds this data type to read from the your H10 (if not already added)
+    /// Adds this data type to read from the your H10 (if not already added).
     pub fn data_type_push(&mut self, data_type: H10MeasurementType) {
         match &mut self.data_type {
             Some(types) => {
@@ -598,7 +598,7 @@ impl PolarSensor {
         };
     }
 
-    /// Removes a data type
+    /// Removes a data type.
     pub fn data_type_pop(&mut self, data_type: H10MeasurementType) {
         if let Some(data) = &mut self.data_type {
             data.retain(|x| *x != data_type);
@@ -608,12 +608,12 @@ impl PolarSensor {
         }
     }
 
-    /// Get data types
+    /// Get data types.
     pub fn data_type(&self) -> &Option<Vec<H10MeasurementType>> {
         &self.data_type
     }
 
-    /// Set data range for acceleration data
+    /// Set data range for acceleration data.
     pub fn range(&mut self, range: u8) -> PolarResult<()> {
         if range == 2 || range == 4 || range == 8 {
             if let Some(ty) = &self.data_type {
@@ -631,7 +631,7 @@ impl PolarSensor {
         Err(Error::InvalidData)
     }
 
-    /// Set sample rate
+    /// Set sample rate.
     pub fn sample_rate(&mut self, rate: u8) -> PolarResult<()> {
         if rate == 25 || rate == 50 || rate == 100 || rate == 200 {
             if let Some(ty) = &self.data_type {
@@ -805,7 +805,7 @@ impl PolarSensor {
     }
 }
 
-/// Private helper to find characteristics from a [`Uuid`]
+/// Private helper to find characteristics from a [`Uuid`].
 async fn find_characteristic(device: &Peripheral, uuid: Uuid) -> PolarResult<Characteristic> {
     device
         .characteristics()

--- a/src/polar_uuid.rs
+++ b/src/polar_uuid.rs
@@ -22,6 +22,7 @@ const SOFTWARE_REVISION_STRING_UUID: Uuid = Uuid::from_u128(0x00002a28_0000_1000
 const SERIAL_NUMBER_STRING_UUID: Uuid = Uuid::from_u128(0x00002a25_0000_1000_8000_00805f9b34fb);
 const SYSTEM_ID_UUID: Uuid = Uuid::from_u128(0x00002a23_0000_1000_8000_00805f9b34fb);
 
+/// Which UUID to send BLE messages to
 pub enum NotifyUuid {
     BatteryLevel,
     HeartMeasurement,

--- a/src/polar_uuid.rs
+++ b/src/polar_uuid.rs
@@ -1,6 +1,6 @@
 //! # Polar UUID
 //!
-//! This module contains constants and enums related to all of the uuid characteristics of the Polar H10
+//! This module contains constants and enums related to all of the UUID characteristics of the Polar H10
 
 use crate::NotifyStream;
 use uuid::Uuid;

--- a/src/polar_uuid.rs
+++ b/src/polar_uuid.rs
@@ -5,9 +5,9 @@
 use crate::NotifyStream;
 use uuid::Uuid;
 
-/// Battery notify stream
+/// Battery notify stream.
 const BATTERY_LEVEL_UUID: Uuid = Uuid::from_u128(0x00002a19_0000_1000_8000_00805f9b34fb);
-/// Heart rate notify stream
+/// Heart rate notify stream.
 const HEART_RATE_SERVICE_UUID: Uuid = Uuid::from_u128(0x00002a37_0000_1000_8000_00805f9b34fb);
 const BODY_LOCATION_UUID: Uuid = Uuid::from_u128(0x00002a38_0000_1000_8000_00805f9b34fb);
 
@@ -22,7 +22,7 @@ const SOFTWARE_REVISION_STRING_UUID: Uuid = Uuid::from_u128(0x00002a28_0000_1000
 const SERIAL_NUMBER_STRING_UUID: Uuid = Uuid::from_u128(0x00002a25_0000_1000_8000_00805f9b34fb);
 const SYSTEM_ID_UUID: Uuid = Uuid::from_u128(0x00002a23_0000_1000_8000_00805f9b34fb);
 
-/// Which UUID to send BLE messages to
+/// Which UUID to send BLE messages to.
 pub enum NotifyUuid {
     BatteryLevel,
     HeartMeasurement,

--- a/src/polar_uuid.rs
+++ b/src/polar_uuid.rs
@@ -33,10 +33,10 @@ pub enum NotifyUuid {
 impl From<NotifyStream> for NotifyUuid {
     fn from(item: NotifyStream) -> Self {
         match item {
-            NotifyStream::Battery => NotifyUuid::BatteryLevel,
-            NotifyStream::HeartRate => NotifyUuid::HeartMeasurement,
-            NotifyStream::MeasurementData => NotifyUuid::MeasurementData,
-            NotifyStream::MeasurementCP => NotifyUuid::MeasurementCP,
+            NotifyStream::Battery => Self::BatteryLevel,
+            NotifyStream::HeartRate => Self::HeartMeasurement,
+            NotifyStream::MeasurementData => Self::MeasurementData,
+            NotifyStream::MeasurementCP => Self::MeasurementCP,
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -49,7 +49,7 @@ pub struct PmdRead {
 }
 
 impl PmdRead {
-    /// Create new `PmdRead`
+    /// Create new [`PmdRead`]
     pub fn new(data_stream: Vec<u8>) -> PolarResult<PmdRead> {
         let data_type = H10MeasurementType::try_from(data_stream[0]);
         if let Err(_e) = data_type {
@@ -119,7 +119,7 @@ pub struct Ecg {
 }
 
 impl Ecg {
-    /// Convert data into ECG data
+    /// Create new instance of [`Ecg`]
     fn new(data: &Vec<u8>) -> PolarResult<Ecg> {
         if data.len() < 3 {
             eprintln!("ECG expects 3 bytes of data, got {}.", data.len());
@@ -148,7 +148,7 @@ pub struct Acc {
 }
 
 impl Acc {
-    /// Convert data into acceleration data
+    /// Create new instance of [`Acc`]
     fn new(data: &Vec<u8>) -> PolarResult<Acc> {
         if data.len() < 2 {
             eprintln!("Acceleration expects 2 bytes of data, got {}", data.len());
@@ -180,7 +180,7 @@ pub struct HeartRate {
 }
 
 impl HeartRate {
-    /// Create new instance of HR data
+    /// Create new instance of [`HeartRate`]
     pub fn new(data: Vec<u8>) -> PolarResult<HeartRate> {
         if data.len() < 2 {
             eprintln!(

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 //! # Response
 //!
-//! Response contains types related to PMD data respones. Structures to interpret this data are found here
+//! Response contains types related to PMD data responses. Structures to interpret this data are found here
 //!
 
 use crate::{Error, H10MeasurementType, PolarResult};
@@ -40,7 +40,7 @@ fn bytes_to_data(data: &[u8], len: usize) -> i32 {
     }
 }
 
-/// Struct for reveiving measurement type data on PMD data
+/// Struct for receiving measurement type data on PMD data
 #[derive(Debug)]
 pub struct PmdRead {
     data_type: H10MeasurementType,
@@ -92,7 +92,7 @@ impl PmdRead {
         &self.data_type
     }
 
-    /// Return timestamp of this data
+    /// Return time stamp of this data
     pub fn time_stamp(&self) -> u64 {
         self.time_stamp
     }
@@ -106,7 +106,7 @@ impl PmdRead {
 /// Enum to store which kind of data was received
 #[derive(Debug)]
 pub enum PmdData {
-    /// Electrocardiagram
+    /// Electrocardiogram
     Ecg(Ecg),
     /// Acceleration
     Acc(Acc),
@@ -212,7 +212,7 @@ impl HeartRate {
         Ok(HeartRate { bpm, rr })
     }
 
-    /// Get BPM of heartrate measurement
+    /// Get BPM of heart rate measurement
     pub fn bpm(&self) -> &u8 {
         &self.bpm
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -50,7 +50,7 @@ pub struct PmdRead {
 
 impl PmdRead {
     /// Create new [`PmdRead`].
-    pub fn new(data_stream: Vec<u8>) -> PolarResult<PmdRead> {
+    pub fn new(data_stream: Vec<u8>) -> PolarResult<Self> {
         let data_type = H10MeasurementType::try_from(data_stream[0]);
         if let Err(_e) = data_type {
             return Err(Error::InvalidData);
@@ -80,7 +80,7 @@ impl PmdRead {
             current_pos += frame_length;
         }
 
-        Ok(PmdRead {
+        Ok(Self {
             data_type,
             time_stamp,
             data,
@@ -88,12 +88,12 @@ impl PmdRead {
     }
 
     /// Return data type of this data.
-    pub fn data_type(&self) -> &H10MeasurementType {
+    pub const fn data_type(&self) -> &H10MeasurementType {
         &self.data_type
     }
 
     /// Return time stamp of this data.
-    pub fn time_stamp(&self) -> u64 {
+    pub const fn time_stamp(&self) -> u64 {
         self.time_stamp
     }
 
@@ -120,7 +120,7 @@ pub struct Ecg {
 
 impl Ecg {
     /// Create new instance of [`Ecg`].
-    fn new(data: &Vec<u8>) -> PolarResult<Ecg> {
+    fn new(data: &Vec<u8>) -> PolarResult<Self> {
         if data.len() < 3 {
             eprintln!("ECG expects 3 bytes of data, got {}.", data.len());
             return Err(Error::InvalidLength);
@@ -130,11 +130,11 @@ impl Ecg {
 
         let val = bytes_to_data(&data[..3], 3);
 
-        Ok(Ecg { val })
+        Ok(Self { val })
     }
 
     /// Return ECG value (in µV).
-    pub fn val(&self) -> &i32 {
+    pub const fn val(&self) -> &i32 {
         &self.val
     }
 }
@@ -149,14 +149,14 @@ pub struct Acc {
 
 impl Acc {
     /// Create new instance of [`Acc`].
-    fn new(data: &Vec<u8>) -> PolarResult<Acc> {
+    fn new(data: &Vec<u8>) -> PolarResult<Self> {
         if data.len() < 2 {
             eprintln!("Acceleration expects 2 bytes of data, got {}", data.len());
             return Err(Error::InvalidLength);
         }
         let frame_size = 6;
 
-        Ok(Acc {
+        Ok(Self {
             x: bytes_to_data(&data[..frame_size / 3], frame_size / 3),
             y: bytes_to_data(&data[frame_size / 3..(frame_size / 3) * 2], frame_size / 3),
             z: bytes_to_data(
@@ -167,7 +167,7 @@ impl Acc {
     }
 
     /// Return data as a tuple (in mG).
-    pub fn data(&self) -> (i32, i32, i32) {
+    pub const fn data(&self) -> (i32, i32, i32) {
         (self.x, self.y, self.z)
     }
 }
@@ -181,7 +181,7 @@ pub struct HeartRate {
 
 impl HeartRate {
     /// Create new instance of [`HeartRate`].
-    pub fn new(data: Vec<u8>) -> PolarResult<HeartRate> {
+    pub fn new(data: Vec<u8>) -> PolarResult<Self> {
         if data.len() < 2 {
             eprintln!(
                 "Heart rate expects atleast 2 bytes of data, got {}",
@@ -190,7 +190,7 @@ impl HeartRate {
             return Err(Error::InvalidLength);
         }
         let flags = data[0];
-        let samples = if flags & 0b00010000 == 16 {
+        let samples = if flags & 0b0001_0000 == 16 {
             (data.len() - 2) / 2
         } else {
             0
@@ -209,16 +209,16 @@ impl HeartRate {
             None
         };
 
-        Ok(HeartRate { bpm, rr })
+        Ok(Self { bpm, rr })
     }
 
     /// Get BPM of heart rate measurement.
-    pub fn bpm(&self) -> &u8 {
+    pub const fn bpm(&self) -> &u8 {
         &self.bpm
     }
 
     /// Get RR interval as a tuple.
-    pub fn rr(&self) -> &Option<Vec<u16>> {
+    pub const fn rr(&self) -> &Option<Vec<u16>> {
         &self.rr
     }
 }
@@ -232,7 +232,7 @@ mod test {
     fn pmd_read_acc_new() {
         let response = PmdRead::new(vec![
             0x02, 0xea, 0x54, 0xa2, 0x42, 0x8b, 0x45, 0x52, 0x08, 0x01, 0x45, 0xff, 0xe4, 0xff,
-            0xb5, 0x03, 0x45, 0xff, 0xe4, 0xff, 0xb8, 03,
+            0xb5, 0x03, 0x45, 0xff, 0xe4, 0xff, 0xb8, 0x03,
         ])
         .unwrap();
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -200,7 +200,9 @@ impl HeartRate {
         let mut rr_samp = vec![];
 
         for i in 0..samples {
-            rr_samp.push(((bytes_to_data(&data[i * 2 + 2..i * 2 + 4], 2) as u32 * 128) / 125) as u16); // rr values are stored as 1024ths of a second, convert to ms
+            rr_samp
+                .push(((bytes_to_data(&data[i * 2 + 2..i * 2 + 4], 2) as u32 * 128) / 125) as u16);
+            // rr values are stored as 1024ths of a second, convert to ms
         }
 
         let rr = if !rr_samp.is_empty() {

--- a/src/response.rs
+++ b/src/response.rs
@@ -40,7 +40,7 @@ fn bytes_to_data(data: &[u8], len: usize) -> i32 {
     }
 }
 
-/// Struct for receiving measurement type data on PMD data
+/// Struct for receiving measurement type data on PMD data.
 #[derive(Debug)]
 pub struct PmdRead {
     data_type: H10MeasurementType,
@@ -49,7 +49,7 @@ pub struct PmdRead {
 }
 
 impl PmdRead {
-    /// Create new [`PmdRead`]
+    /// Create new [`PmdRead`].
     pub fn new(data_stream: Vec<u8>) -> PolarResult<PmdRead> {
         let data_type = H10MeasurementType::try_from(data_stream[0]);
         if let Err(_e) = data_type {
@@ -87,39 +87,39 @@ impl PmdRead {
         })
     }
 
-    /// Return data type of this data
+    /// Return data type of this data.
     pub fn data_type(&self) -> &H10MeasurementType {
         &self.data_type
     }
 
-    /// Return time stamp of this data
+    /// Return time stamp of this data.
     pub fn time_stamp(&self) -> u64 {
         self.time_stamp
     }
 
-    /// Consumes self and returns all data
+    /// Consumes self and returns all data.
     pub fn data(self) -> Vec<PmdData> {
         self.data
     }
 }
 
-/// Enum to store which kind of data was received
+/// Enum to store which kind of data was received.
 #[derive(Debug)]
 pub enum PmdData {
-    /// Electrocardiogram
+    /// Electrocardiogram.
     Ecg(Ecg),
-    /// Acceleration
+    /// Acceleration.
     Acc(Acc),
 }
 
-/// Struct to store ECG from the PMD data stream
+/// Struct to store ECG from the PMD data stream.
 #[derive(Debug)]
 pub struct Ecg {
     val: i32,
 }
 
 impl Ecg {
-    /// Create new instance of [`Ecg`]
+    /// Create new instance of [`Ecg`].
     fn new(data: &Vec<u8>) -> PolarResult<Ecg> {
         if data.len() < 3 {
             eprintln!("ECG expects 3 bytes of data, got {}.", data.len());
@@ -133,13 +133,13 @@ impl Ecg {
         Ok(Ecg { val })
     }
 
-    /// Return ECG value (in µV)
+    /// Return ECG value (in µV).
     pub fn val(&self) -> &i32 {
         &self.val
     }
 }
 
-/// Struct to store acceleration from the PMD data stream
+/// Struct to store acceleration from the PMD data stream.
 #[derive(Debug)]
 pub struct Acc {
     x: i32,
@@ -148,7 +148,7 @@ pub struct Acc {
 }
 
 impl Acc {
-    /// Create new instance of [`Acc`]
+    /// Create new instance of [`Acc`].
     fn new(data: &Vec<u8>) -> PolarResult<Acc> {
         if data.len() < 2 {
             eprintln!("Acceleration expects 2 bytes of data, got {}", data.len());
@@ -166,13 +166,13 @@ impl Acc {
         })
     }
 
-    /// Return data as a tuple (in mG)
+    /// Return data as a tuple (in mG).
     pub fn data(&self) -> (i32, i32, i32) {
         (self.x, self.y, self.z)
     }
 }
 
-/// Structure to contain HR data and RR interval
+/// Structure to contain HR data and RR interval.
 #[derive(Debug)]
 pub struct HeartRate {
     bpm: u8,
@@ -180,7 +180,7 @@ pub struct HeartRate {
 }
 
 impl HeartRate {
-    /// Create new instance of [`HeartRate`]
+    /// Create new instance of [`HeartRate`].
     pub fn new(data: Vec<u8>) -> PolarResult<HeartRate> {
         if data.len() < 2 {
             eprintln!(
@@ -212,12 +212,12 @@ impl HeartRate {
         Ok(HeartRate { bpm, rr })
     }
 
-    /// Get BPM of heart rate measurement
+    /// Get BPM of heart rate measurement.
     pub fn bpm(&self) -> &u8 {
         &self.bpm
     }
 
-    /// Get RR interval as a tuple
+    /// Get RR interval as a tuple.
     pub fn rr(&self) -> &Option<Vec<u16>> {
         &self.rr
     }


### PR DESCRIPTION
I was reading through the docs and found a few spelling mistakes. I added periods to the end of all the sentences to stay consistent throughout the code. I used [cargo-semver-checks](https://crates.io/crates/cargo-semver-checks) and [cargo-spell-check](https://crates.io/crates/cargo-spellcheck) to find errors and ensure backwards compatibility. 

I also ran clippy on the nursery and pedantic levels and fixed all of the nursery errors and a few of the pedantic ones. Most of the code changes were making functions `const` and replacing `struct`/`enum` names with `Self` where possible.